### PR TITLE
corrected calculatePassiveProperties.m to allow one-compartment model…

### DIFF
--- a/vertex/vertex_simulate/setupFunctions/calculatePassiveProperties.m
+++ b/vertex/vertex_simulate/setupFunctions/calculatePassiveProperties.m
@@ -4,7 +4,7 @@ function [NeuronArr] = ...
 % Calculate passive neuron properties in correct units
 numGroups = TissueProperties.numGroups;
 for iGroup = 1:numGroups
-  if NeuronArr(iGroup).numCompartments > 1
+  if NeuronArr(iGroup).numCompartments >= 1
     l = NeuronArr(iGroup).compartmentLengthArr .* 10^-4; % in cm
     d = NeuronArr(iGroup).compartmentDiameterArr .* 10^-4; % in cm
     %if NeuronArr(iGroup).homogeneous


### PR DESCRIPTION
One-compartment models are successfully initialized and run only when NeuronArr(iGroup).numCompartments >=1 instead of >1. Thus I suggest to change to >=1.
Regards, Rokas

@richardtomsett 
