### PR TITLE
Fix step input current

### DIFF
--- a/vertex/vertex_simulate/models/inputs/InputModel_i_step.m
+++ b/vertex/vertex_simulate/models/inputs/InputModel_i_step.m
@@ -47,14 +47,14 @@ classdef InputModel_i_step < InputModel
         IM.stepOn  = round(N.Input.timeOn  / timeStep);
       end
       IM.stepOff = round(N.Input.timeOff / timeStep);
-      IM.I_input = 0;
+      IM.I_input(:) = 0;
     end
     
     function IM = updateInput(IM, ~)
       if IM.count == IM.stepOn
-        IM.I_input = IM.meanInput;
+        IM.I_input = repmat(IM.meanInput, size(IM.I_input, 1), 1);
       elseif IM.count == IM.stepOff
-        IM.I_input = 0;
+        IM.I_input(:) = 0;
       end
       IM.count = IM.count + 1;
     end


### PR DESCRIPTION
Hello!

I have problems when trying to use the step current input. Modifying tutorial 2, for example, with

```
NeuronParams(1).Input(1).inputType = 'i_step';
NeuronParams(1).Input(1).timeOn = 1;
NeuronParams(1).Input(1).timeOff = 100;
NeuronParams(1).Input(1).amplitude = 200;
```

the simulation gives

```
...
100%  line source constants calculated ...
Model successfully initialised!
Error using +
Matrix dimensions must agree.

Error in NeuronModel_adex/updateNeurons (line 28)
      kv = bsxfun(@rdivide, (-bsxfun(@times, N.g_l, (NM.v - N.E_leak)) -...


Error in groupUpdateSchedule (line 28)
  updateNeurons(NeuronModel{iGroup}, InModel(iGroup, :), ...

Error in simulate (line 54)
    [NeuronModel, SynModel, InModel] = ...

Error in runSimulation (line 128)
    simulate(TP, NP, SS, RS, NeuronIDMap, NeuronModelArr, ...

Error in tutorial_2 (line 274)
runSimulation(params, connections, electrodes);
```

The issue seems to be that the code in `NeuronModel_adex` is expecting an N x M matrix for input current, where N is the number of neurons and M is the number of compartments per neuron, but `InputModel_i_step` only produces a 1 x M matrix:

```
    function IM = setupStepCurrent(IM, N, inputID, timeStep)                    
      mi = N.Input(inputID).amplitude(:);                                       
      IM.meanInput = bsxfun(@times, mi, IM.membraneAreaRatio);
...
    function IM = updateInput(IM, ~)                                            
      if IM.count == IM.stepOn                                                  
        IM.I_input = IM.meanInput;
```

This doesn't happen in `InputModel_i_ou` because a `bsxfun` is performed on `meanInput`, causing singleton expansion:

```
function IM = updateInput(IM, ~)                                            
      IM.I_input = IM.I_input + ...                                             
        bsxfun(@plus, ...                                                       
        bsxfun( @times, IM.optInputPars.expMinusLambdaDelta_t, ...              
        bsxfun(@minus, IM.optInputPars.meanInput, IM.I_input) ), ...
```

This branch fixes the issue by just doing a `repmat` on `meanInput` inside `InputModel_i_step`.

Thanks! :)
Matthew
